### PR TITLE
fix: Namespace subscribed feeds provider authority

### DIFF
--- a/play-services-core/src/main/AndroidManifest.xml
+++ b/play-services-core/src/main/AndroidManifest.xml
@@ -289,7 +289,7 @@
             android:exported="true" />
         <provider
             android:name="org.microg.gms.feeds.SubscribedFeedsProvider"
-            android:authorities="subscribedfeeds"
+            android:authorities="${basePackageName}.android.gsf.subscribedfeeds"
             android:exported="true"
             android:multiprocess="false"
             android:readPermission="android.permission.SUBSCRIBED_FEEDS_READ"


### PR DESCRIPTION
### Summary

The `SubscribedFeedsProvider` was registered using the global authority:

```text
subscribedfeeds
```

This conflicts with the provider already registered by Google Services Framework (`com.google.android.gsf`) on some devices, causing installation to fail with an authority conflict.

The provider now uses the package-scoped authority:

```text
${basePackageName}.android.gsf.subscribedfeeds
```

### Changes

- Namespaced the `SubscribedFeedsProvider` authority.
- Preserved the provider implementation and permissions.
- Avoided conflicts with system-installed Google Services Framework.
- No other provider authorities were changed.