### PR TITLE
ci: Strip non-target ABIs from arm64 release APKs

### DIFF
--- a/play-services-core/build.gradle
+++ b/play-services-core/build.gradle
@@ -172,7 +172,26 @@ android {
 
         ndk {
             def requestedAbi = project.findProperty("abi")
-            abiFilters requestedAbi ? requestedAbi : "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
+            // With -Pabi set, ABI splits below handle filtering; an ndk abiFilters
+            // would conflict with the split filters.
+            if (!requestedAbi) {
+                abiFilters "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
+            }
+        }
+    }
+
+    // ABI splits: when -Pabi=<abi> is set, package ONLY that ABI's native libs
+    // (ndk.abiFilters above does not strip jniLibs shipped inside AAR dependencies).
+    splits {
+        abi {
+            if (project.hasProperty("abi")) {
+                enable true
+                reset()
+                include project.property("abi")
+                universalApk false
+            } else {
+                enable false
+            }
         }
     }
 


### PR DESCRIPTION
`ndk.abiFilters` doesn't strip jniLibs from AAR dependencies, so the arm64 release builds still packed x86/x86_64 libs (~93 MB). Switched to ABI splits, which filter merged native libs at packaging arm64 APK is now ~44 MB; universal build unchanged.