### PR TITLE
feat(settings): Add in-app language picker

### DIFF
--- a/play-services-core/src/main/kotlin/org/microg/gms/ui/SettingsFragment.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/ui/SettingsFragment.kt
@@ -17,12 +17,16 @@ import android.os.PowerManager
 import androidx.core.net.toUri
 import android.util.Log
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import androidx.preference.SwitchPreferenceCompat
 import com.google.android.gms.R
+import java.util.Locale
 import com.google.android.material.transition.MaterialSharedAxis
 import org.microg.gms.checkin.CheckinPreferences
 import org.microg.gms.common.ForegroundServiceOemUtils
@@ -97,6 +101,7 @@ class SettingsFragment : ResourceSettingsFragment() {
             openGithub()
             true
         }
+        setupLanguagePreference()
 
         findPreference<Preference>(PREF_ABOUT)!!.apply {
             onPreferenceClickListener = Preference.OnPreferenceClickListener {
@@ -162,6 +167,7 @@ class SettingsFragment : ResourceSettingsFragment() {
 
         findPreference<Preference>(PREF_CHECKIN)!!.setSummary(if (CheckinPreferences.isEnabled(requireContext())) org.microg.gms.base.core.R.string.service_status_enabled_short else org.microg.gms.base.core.R.string.service_status_disabled_short)
         findPreference<Preference>(PREF_SNET)!!.setSummary(if (SafetyNetPreferences.isEnabled(requireContext())) org.microg.gms.base.core.R.string.service_status_enabled_short else org.microg.gms.base.core.R.string.service_status_disabled_short)
+        updateLanguagePreferenceSummary()
 
         lifecycleScope.launchWhenResumed {
             val entries = getAllSettingsProviders(requireContext()).flatMap { it.getEntriesDynamic(requireContext()) }
@@ -228,6 +234,54 @@ class SettingsFragment : ResourceSettingsFragment() {
         findPreference<SwitchPreferenceCompat>(PREF_HIDE_LAUNCHER_ICON)?.isChecked = isHidden
     }
 
+    private fun setupLanguagePreference() {
+        val preference = findPreference<ListPreference>(PREF_LANGUAGE) ?: return
+        val tags = resources.getStringArray(R.array.pref_language_values)
+        val entries = arrayOfNulls<String>(tags.size + 1)
+        val values = arrayOfNulls<String>(tags.size + 1)
+        entries[0] = getString(R.string.pref_language_system_default)
+        values[0] = ""
+        for (i in tags.indices) {
+            values[i + 1] = tags[i]
+            entries[i + 1] = displayName(tags[i])
+        }
+        preference.entries = entries
+        preference.entryValues = values
+        preference.setOnPreferenceChangeListener { _, newValue ->
+            val tag = newValue as String
+            AppCompatDelegate.setApplicationLocales(
+                if (tag.isEmpty()) LocaleListCompat.getEmptyLocaleList() else LocaleListCompat.forLanguageTags(tag)
+            )
+            updateLanguagePreferenceSummary()
+            true
+        }
+        updateLanguagePreferenceSummary()
+    }
+
+    private fun updateLanguagePreferenceSummary() {
+        val preference = findPreference<ListPreference>(PREF_LANGUAGE) ?: return
+        val current = AppCompatDelegate.getApplicationLocales().get(0)
+        if (current == null) {
+            preference.value = ""
+            preference.summary = getString(R.string.pref_language_system_default)
+        } else {
+            val tag = current.toLanguageTag()
+            preference.value = tag
+            preference.summary = displayName(tag)
+        }
+    }
+
+    private fun displayName(tag: String): String {
+        // "in"/"iw" are legacy ISO codes; use the modern ones for display only.
+        val displayTag = when {
+            tag.startsWith("in-") -> "id-" + tag.substring(3)
+            tag.startsWith("iw-") -> "he-" + tag.substring(3)
+            else -> tag
+        }
+        val locale = Locale.forLanguageTag(displayTag)
+        return locale.getDisplayName(locale)
+    }
+
     private fun openGithub() {
         try {
             startActivity(Intent(Intent.ACTION_VIEW, PREF_GITHUB_URL.toUri()))
@@ -254,6 +308,7 @@ class SettingsFragment : ResourceSettingsFragment() {
         const val PREF_ACCOUNTS = "pref_accounts"
         const val PREF_HIDE_LAUNCHER_ICON = "pref_hide_launcher_icon"
         const val PREF_GITHUB = "pref_github"
+        const val PREF_LANGUAGE = "pref_language"
         const val PREF_PRIVACY = "pref_privacy"
         const val PREF_IGNORE_BATTERY_OPTIMIZATION = "pref_ignore_battery_optimization"
 

--- a/play-services-core/src/main/res/drawable/ic_language.xml
+++ b/play-services-core/src/main/res/drawable/ic_language.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM11,19.93c-3.95,-0.49 -7,-3.85 -7,-7.93 0,-0.62 0.08,-1.21 0.21,-1.79L9,15v1c0,1.1 0.9,2 2,2v1.93zM17.9,17.39c-0.26,-0.81 -1,-1.39 -1.9,-1.39h-1v-3c0,-0.55 -0.45,-1 -1,-1L8,12v-2h2c0.55,0 1,-0.45 1,-1L11,7h2c1.1,0 2,-0.9 2,-2v-0.41c2.93,1.19 5,4.06 5,7.41 0,2.08 -0.8,3.97 -2.1,5.39z" />
+</vector>

--- a/play-services-core/src/main/res/values/arrays.xml
+++ b/play-services-core/src/main/res/values/arrays.xml
@@ -62,7 +62,6 @@
         <item>am-ET</item>
         <item>ar-SA</item>
         <item>as-IN</item>
-        <item>ast</item>
         <item>az-AZ</item>
         <item>be-BY</item>
         <item>bg-BG</item>
@@ -75,7 +74,6 @@
         <item>de-DE</item>
         <item>el-GR</item>
         <item>en</item>
-        <item>eo</item>
         <item>es-ES</item>
         <item>et-EE</item>
         <item>eu-ES</item>
@@ -101,10 +99,8 @@
         <item>lo-LA</item>
         <item>lt-LT</item>
         <item>lv-LV</item>
-        <item>lzh</item>
         <item>mai-IN</item>
         <item>mk-MK</item>
-        <item>ml</item>
         <item>mn-MN</item>
         <item>mr-IN</item>
         <item>ms-MY</item>
@@ -128,7 +124,6 @@
         <item>te-IN</item>
         <item>th-TH</item>
         <item>tr-TR</item>
-        <item>ug</item>
         <item>uk-UA</item>
         <item>ur-IN</item>
         <item>uz-UZ</item>

--- a/play-services-core/src/main/res/values/arrays.xml
+++ b/play-services-core/src/main/res/values/arrays.xml
@@ -124,6 +124,7 @@
         <item>te-IN</item>
         <item>th-TH</item>
         <item>tr-TR</item>
+        <item>ug</item>
         <item>uk-UA</item>
         <item>ur-IN</item>
         <item>uz-UZ</item>

--- a/play-services-core/src/main/res/values/arrays.xml
+++ b/play-services-core/src/main/res/values/arrays.xml
@@ -55,4 +55,85 @@
         <item>Ping interval: 20 minutes</item>
         <item>Ping interval: 30 minutes</item>
     </string-array>
+
+    <!-- Locale tags of every language the app is translated into (must mirror locales_config.xml). -->
+    <string-array name="pref_language_values" translatable="false">
+        <item>af-ZA</item>
+        <item>am-ET</item>
+        <item>ar-SA</item>
+        <item>as-IN</item>
+        <item>ast</item>
+        <item>az-AZ</item>
+        <item>be-BY</item>
+        <item>bg-BG</item>
+        <item>bn-BD</item>
+        <item>bs-BA</item>
+        <item>ca-ES</item>
+        <item>ckb-IR</item>
+        <item>cs-CZ</item>
+        <item>da-DK</item>
+        <item>de-DE</item>
+        <item>el-GR</item>
+        <item>en</item>
+        <item>eo</item>
+        <item>es-ES</item>
+        <item>et-EE</item>
+        <item>eu-ES</item>
+        <item>fa-IR</item>
+        <item>fi-FI</item>
+        <item>fil-PH</item>
+        <item>fr-FR</item>
+        <item>ga-IE</item>
+        <item>gl-ES</item>
+        <item>gu-IN</item>
+        <item>in-ID</item>
+        <item>is-IS</item>
+        <item>it-IT</item>
+        <item>iw-IL</item>
+        <item>ja-JP</item>
+        <item>ka-GE</item>
+        <item>kk-KZ</item>
+        <item>km-KH</item>
+        <item>kmr-TR</item>
+        <item>kn-IN</item>
+        <item>ko-KR</item>
+        <item>ky-KG</item>
+        <item>lo-LA</item>
+        <item>lt-LT</item>
+        <item>lv-LV</item>
+        <item>lzh</item>
+        <item>mai-IN</item>
+        <item>mk-MK</item>
+        <item>ml</item>
+        <item>mn-MN</item>
+        <item>mr-IN</item>
+        <item>ms-MY</item>
+        <item>my-MM</item>
+        <item>nb-NO</item>
+        <item>ne-IN</item>
+        <item>nl-NL</item>
+        <item>or-IN</item>
+        <item>pa-IN</item>
+        <item>pl-PL</item>
+        <item>pt-BR</item>
+        <item>pt-PT</item>
+        <item>ro-RO</item>
+        <item>ru-RU</item>
+        <item>si-LK</item>
+        <item>sk-SK</item>
+        <item>sl-SI</item>
+        <item>sr-SP</item>
+        <item>sv-SE</item>
+        <item>ta-IN</item>
+        <item>te-IN</item>
+        <item>th-TH</item>
+        <item>tr-TR</item>
+        <item>ug</item>
+        <item>uk-UA</item>
+        <item>ur-IN</item>
+        <item>uz-UZ</item>
+        <item>zh-CN</item>
+        <item>zh-TW</item>
+        <item>zu-ZA</item>
+    </string-array>
 </resources>

--- a/play-services-core/src/main/res/values/strings.xml
+++ b/play-services-core/src/main/res/values/strings.xml
@@ -225,6 +225,8 @@ Please set up a password, PIN, or pattern lock screen."</string>
 
     <string name="pref_about_title">About MicroG RE</string>
     <string name="pref_hide_launcher_icon">Hide icon in launcher</string>
+    <string name="pref_language_title">Language</string>
+    <string name="pref_language_system_default">System default</string>
     <string name="pref_github" translatable="false">GitHub</string>
     <string name="pref_github_summary">Source code repository</string>
     <string name="pref_about_summary" translatable="false">Version information and used libraries</string>

--- a/play-services-core/src/main/res/xml/locales_config.xml
+++ b/play-services-core/src/main/res/xml/locales_config.xml
@@ -4,7 +4,6 @@
     <locale android:name="am-ET" />
     <locale android:name="ar-SA" />
     <locale android:name="as-IN" />
-    <locale android:name="ast" />
     <locale android:name="az-AZ" />
     <locale android:name="be-BY" />
     <locale android:name="bg-BG" />
@@ -17,7 +16,6 @@
     <locale android:name="de-DE" />
     <locale android:name="el-GR" />
     <locale android:name="en" />
-    <locale android:name="eo" />
     <locale android:name="es-ES" />
     <locale android:name="et-EE" />
     <locale android:name="eu-ES" />
@@ -43,10 +41,8 @@
     <locale android:name="lo-LA" />
     <locale android:name="lt-LT" />
     <locale android:name="lv-LV" />
-    <locale android:name="lzh" />
     <locale android:name="mai-IN" />
     <locale android:name="mk-MK" />
-    <locale android:name="ml" />
     <locale android:name="mn-MN" />
     <locale android:name="mr-IN" />
     <locale android:name="ms-MY" />
@@ -70,7 +66,6 @@
     <locale android:name="te-IN" />
     <locale android:name="th-TH" />
     <locale android:name="tr-TR" />
-    <locale android:name="ug" />
     <locale android:name="uk-UA" />
     <locale android:name="ur-IN" />
     <locale android:name="uz-UZ" />

--- a/play-services-core/src/main/res/xml/locales_config.xml
+++ b/play-services-core/src/main/res/xml/locales_config.xml
@@ -66,6 +66,7 @@
     <locale android:name="te-IN" />
     <locale android:name="th-TH" />
     <locale android:name="tr-TR" />
+    <locale android:name="ug" />
     <locale android:name="uk-UA" />
     <locale android:name="ur-IN" />
     <locale android:name="uz-UZ" />

--- a/play-services-core/src/main/res/xml/preferences_start.xml
+++ b/play-services-core/src/main/res/xml/preferences_start.xml
@@ -97,6 +97,13 @@
         android:layout="@layout/preference_material_middle"
         android:summary="@string/pref_github_summary"
         android:title="@string/pref_github" />
+    <ListPreference
+        android:defaultValue=""
+        android:icon="@drawable/ic_language"
+        android:key="pref_language"
+        android:layout="@layout/preference_material_middle"
+        android:summary="@string/pref_language_system_default"
+        android:title="@string/pref_language_title" />
     <PreferenceCategory
         android:key="prefcat_footer"
         android:layout="@layout/preference_material_category_none" />


### PR DESCRIPTION
Devices without per-app language support (older Android or custom OSes) could not change the app language. Add a Language entry to Settings that applies AppCompatDelegate.setApplicationLocales for every locale the app is translated into, plus a System default option. On Android 13+ it shares the platform per-app locale storage, so it stays in sync with the system language picker in both directions.

<img width="288" height="617" alt="image" src="https://github.com/user-attachments/assets/81f53fe7-444f-45b8-a2d1-78249132fc8f" />

<img width="308" height="619" alt="image" src="https://github.com/user-attachments/assets/f19ae82e-0a6f-4775-b22d-30fe40063fd1" />


Fixes #50, #226