### PR TITLE
feat: Support GoogleIdService

### DIFF
--- a/play-services-core/src/main/AndroidManifest.xml
+++ b/play-services-core/src/main/AndroidManifest.xml
@@ -762,13 +762,22 @@
                 android:name="android.credentials.provider"
                 android:resource="@xml/credentials_provider_passkey" />
         </service>
+        
+        <service
+            android:name="com.google.android.gms.auth.api.credentials.credman.service.GoogleIdService"
+            android:exported="true"
+            android:icon="@drawable/ic_google_logo"
+            android:label="@string/credentials_service_sign_in_with_google_label"
+            android:permission="android.permission.BIND_CREDENTIAL_PROVIDER_SERVICE"
+            tools:targetApi="34">
+            <intent-filter>
+                <action android:name="android.service.credentials.CredentialProviderService"/>
+            </intent-filter>
+            <meta-data
+                android:name="android.credentials.provider"
+                android:resource="@xml/credentials_provider_google_id" />
+        </service>
 
-        <!-- The android.service.credentials.system.* provider services (GoogleIdService /
-             RemoteService) are privileged-only in real Play services; declaring them in a
-             re-signed (non-system) package makes the platform's CredentialManager UI-launch
-             path fail with NameNotFoundException when building the provider picker. The regular
-             PasswordAndPasskeyService provider above is the path third-party installs are
-             queried through, so the system-level providers are intentionally not declared. -->
 
         <activity
             android:name="org.microg.gms.auth.credentials.provider.PublicKeyProxyActivity"

--- a/play-services-core/src/main/kotlin/org/microg/gms/auth/credentials/provider/GoogleIdService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/auth/credentials/provider/GoogleIdService.kt
@@ -175,7 +175,7 @@ const val GOOGLE_ID_BUNDLE_KEY_PROFILE_PICTURE_URI = "com.google.android.librari
 const val GOOGLE_ID_FILTER_BY_AUTHORIZED_ACCOUNTS = "com.google.android.libraries.identity.googleid.BUNDLE_KEY_FILTER_BY_AUTHORIZED_ACCOUNTS"
 
 // Credential types
-const val TYPE_GOOGLE_ID_TOKEN_CREDENTIAL = "com.google.android.libraries.identity.googleid.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL"
+const val TYPE_GOOGLE_ID_TOKEN_CREDENTIAL = "app.revanced.android.libraries.identity.googleid.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL"
 
 data class GoogleIdRequestParams(
     val isSignInWithGoogle: Boolean,

--- a/play-services-core/src/main/kotlin/org/microg/gms/auth/credentials/provider/GoogleIdService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/auth/credentials/provider/GoogleIdService.kt
@@ -30,6 +30,7 @@ import androidx.credentials.provider.CustomCredentialEntry
 import com.google.android.gms.R
 import org.microg.gms.auth.credentials.provider.GoogleIdRequestParams.Companion.toGoogleIdRequestParams
 import org.microg.gms.auth.AuthConstants
+import org.microg.gms.base.core.BuildConfig
 
 private const val TAG = "GoogleIdService"
 
@@ -175,7 +176,7 @@ const val GOOGLE_ID_BUNDLE_KEY_PROFILE_PICTURE_URI = "com.google.android.librari
 const val GOOGLE_ID_FILTER_BY_AUTHORIZED_ACCOUNTS = "com.google.android.libraries.identity.googleid.BUNDLE_KEY_FILTER_BY_AUTHORIZED_ACCOUNTS"
 
 // Credential types
-const val TYPE_GOOGLE_ID_TOKEN_CREDENTIAL = "app.revanced.android.libraries.identity.googleid.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL"
+const val TYPE_GOOGLE_ID_TOKEN_CREDENTIAL = "${BuildConfig.BASE_PACKAGE_NAME}.android.libraries.identity.googleid.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL"
 
 data class GoogleIdRequestParams(
     val isSignInWithGoogle: Boolean,

--- a/play-services-core/src/main/res/xml/credentials_provider_google_id.xml
+++ b/play-services-core/src/main/res/xml/credentials_provider_google_id.xml
@@ -5,6 +5,7 @@
     android:settingsActivity="org.microg.gms.ui.SettingsActivity"
     tools:targetApi="34">
     <capabilities>
-        <capability name="com.google.android.libraries.identity.googleid.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL"/>
+        <!-- Custom capability string bypassing system check -->
+        <capability name="app.revanced.android.libraries.identity.googleid.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL"/>
     </capabilities>
 </credential-provider>


### PR DESCRIPTION
This will require changes to the support patch, but getting google sign-in working with the `CredentialManager` was the main reason I needed the rebase.

I have the patch changes working with a single app, but I want to do some more testing on other APKs before I PR into the patches repo.

This change shouldn't have any effect on current users