### PR TITLE
fix(auth): Return recovery PendingIntent for modern clients

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/auth/AuthManagerServiceImpl.java
+++ b/play-services-core/src/main/java/org/microg/gms/auth/AuthManagerServiceImpl.java
@@ -20,6 +20,7 @@ import android.accounts.Account;
 import android.accounts.AccountManager;
 import android.annotation.SuppressLint;
 import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -77,6 +78,7 @@ public class AuthManagerServiceImpl extends IAuthManagerService.Stub {
 
     public static final String KEY_ERROR = "Error";
     public static final String KEY_USER_RECOVERY_INTENT = "userRecoveryIntent";
+    public static final String KEY_USER_RECOVERY_PENDING_INTENT = "userRecoveryPendingIntent";
 
     private final Context context;
 
@@ -171,16 +173,18 @@ public class AuthManagerServiceImpl extends IAuthManagerService.Stub {
                 } catch (Exception e) {
                     Log.w(TAG, "Can't decode consent data: ", e);
                 }
+                PendingIntent pendingIntent = PendingIntentCompat.getActivity(context, 0, i, 0, false);
                 if (notify) {
                     NotificationManager nm = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
                     nm.notify(packageName.hashCode(), new NotificationCompat.Builder(context)
-                            .setContentIntent(PendingIntentCompat.getActivity(context, 0, i, 0, false))
+                            .setContentIntent(pendingIntent)
                             .setContentTitle(context.getString(R.string.auth_notification_title))
                             .setContentText(context.getString(R.string.auth_notification_content, getPackageLabel(packageName, context.getPackageManager())))
                             .setSmallIcon(android.R.drawable.stat_notify_error)
                             .build());
                 }
                 result.putParcelable(KEY_USER_RECOVERY_INTENT, i);
+                result.putParcelable(KEY_USER_RECOVERY_PENDING_INTENT, pendingIntent);
             }
         } catch (IOException e) {
             Log.w(TAG, e);


### PR DESCRIPTION
## Summary

- return the auth recovery activity as `userRecoveryPendingIntent`
- retain the existing `userRecoveryIntent` for older clients
- reuse the same `PendingIntent` for the auth notification

## Why

Modern GoogleAuthUtil reads both `userRecoveryIntent` and `userRecoveryPendingIntent`. For advertised GmsCore versions at or above `233800000`, it explicitly reports a missing recovery `PendingIntent` as a GmsCore implementation bug.

This surfaced with Morphe YouTube 21.07.247: an OAuth scope permission request returned `NeedPermission`, but the authorization UI could not be surfaced correctly and the account list remained loading.

## Verification

- `./gradlew --no-daemon :play-services-core:assembleDefaultRelease -Pabi=arm64-v8a`
- installed the locally signed arm64 build on a OnePlus device running Android 16
- re-added the MicroG account and confirmed Morphe YouTube loads it successfully
- confirmed the original missing-PendingIntent, `NEED_PERMISSION`, credential re-entry, and account-list errors no longer occur
